### PR TITLE
Password not null in User class

### DIFF
--- a/paw-webapp/model/src/main/java/ar/edu/itba/paw/webapp/model/User.java
+++ b/paw-webapp/model/src/main/java/ar/edu/itba/paw/webapp/model/User.java
@@ -87,9 +87,8 @@ public class User implements Serializable, ValidationExceptionThrower, ScoreChec
      */
     public User(String username, String email, String hashedPassword) throws ValidationException {
         this();
-        if (hashedPassword == null) {
-            throw new IllegalArgumentException("A hashed password must be set");
-        }
+        checkPasswordNotNull(hashedPassword); // Throws exception if null
+
         List<ValueError> errorList = new LinkedList<>();
         checkValues(username, email, errorList);
 
@@ -107,9 +106,8 @@ public class User implements Serializable, ValidationExceptionThrower, ScoreChec
      * @param newHashedPassword The new password.
      */
     public void changePassword(String newHashedPassword) {
-        if (newHashedPassword == null) {
-            throw new IllegalArgumentException("A hashed password must be set");
-        }
+        checkPasswordNotNull(newHashedPassword); // Throws exception if null
+
         this.hashedPassword = newHashedPassword;
     }
 
@@ -503,5 +501,17 @@ public class User implements Serializable, ValidationExceptionThrower, ScoreChec
                 ValueErrorConstants.MIME_TYPE_TOO_LONG);
 
         throwValidationException(errorList);
+    }
+
+    /**
+     * Checks that the given {@code password} is not {@code null}.
+     *
+     * @param password The password to validate.
+     * @throws IllegalArgumentException If The given {@code password} is null.
+     */
+    private static void checkPasswordNotNull(String password) throws IllegalArgumentException {
+        if (password == null) {
+            throw new IllegalArgumentException("A hashed password must be set");
+        }
     }
 }

--- a/paw-webapp/model/src/main/java/ar/edu/itba/paw/webapp/model/User.java
+++ b/paw-webapp/model/src/main/java/ar/edu/itba/paw/webapp/model/User.java
@@ -87,8 +87,11 @@ public class User implements Serializable, ValidationExceptionThrower, ScoreChec
      */
     public User(String username, String email, String hashedPassword) throws ValidationException {
         this();
+        if (hashedPassword == null) {
+            throw new IllegalArgumentException("A hashed password must be set");
+        }
         List<ValueError> errorList = new LinkedList<>();
-        checkValues(username, email, hashedPassword, errorList);
+        checkValues(username, email, errorList);
 
         this.username = username;
         this.email = email;
@@ -104,6 +107,9 @@ public class User implements Serializable, ValidationExceptionThrower, ScoreChec
      * @param newHashedPassword The new password.
      */
     public void changePassword(String newHashedPassword) {
+        if (newHashedPassword == null) {
+            throw new IllegalArgumentException("A hashed password must be set");
+        }
         this.hashedPassword = newHashedPassword;
     }
 
@@ -398,11 +404,10 @@ public class User implements Serializable, ValidationExceptionThrower, ScoreChec
      *
      * @param username  The username be checked.
      * @param email     The email to be checked.
-     * @param password  The password to be checked.
      * @param errorList A list containing possible detected errors before calling this method.
      * @throws ValidationException If any value is wrong.
      */
-    private void checkValues(String username, String email, String password, List<ValueError> errorList) throws ValidationException {
+    private void checkValues(String username, String email, List<ValueError> errorList) throws ValidationException {
         errorList = errorList == null ? new LinkedList<>() : errorList;
         ValidationHelper.stringNotNullAndLengthBetweenTwoValues(username, NumericConstants.USERNAME_MIN_LENGTH,
                 NumericConstants.USERNAME_MAX_LENGTH, errorList, ValueErrorConstants.MISSING_USERNAME,
@@ -499,6 +504,4 @@ public class User implements Serializable, ValidationExceptionThrower, ScoreChec
 
         throwValidationException(errorList);
     }
-
-
 }


### PR DESCRIPTION
closes #106 

After merging this branch, when setting a ```null``` password, an ```IllegalArgumentException``` will be thrown.

Note that this is not part of the error system. It's just a check to avoid a ```User ``` gets a ```null``` as a password. This just avoids programmer's errors.

Password validation is performed at service layer as it's a business domain matter (which defines what is a valid password).