### PR TITLE
Fix and improve rating/stars

### DIFF
--- a/app/scripts/build.js
+++ b/app/scripts/build.js
@@ -28,6 +28,7 @@ require.config({
         FeedService: 'services/FeedService',
         loadingCircle: 'directives/loadingCircle',
         loadingCircleSmall: 'directives/loadingCircleSmall',
+        ratingStars: 'directives/ratingStars',
         'angular-local-storage': '../../bower_components/angular-local-storage/dist/angular-local-storage',
         'ng-file-upload': '../../bower_components/ng-file-upload/ng-file-upload',
         ngSweetAlert: '../../bower_components/ngSweetAlert/SweetAlert',
@@ -143,6 +144,11 @@ require.config({
             deps: [
                 'angular'
             ]
+        },
+        'ratingStars': {
+          deps: [
+            'angular'
+          ]
         },
         AuthService: {
             deps: [

--- a/app/scripts/controllers/ListsCtrl.js
+++ b/app/scripts/controllers/ListsCtrl.js
@@ -1,5 +1,5 @@
 'use strict';
-define(['powerUp', 'slick-carousel', 'onComplete', 'sweetalert.angular', 'loadingCircle', 'PaginationService'], function(powerUp) {
+define(['powerUp', 'slick-carousel', 'onComplete', 'sweetalert.angular', 'loadingCircle', 'ratingStars', 'PaginationService'], function(powerUp) {
 
     powerUp.controller('ListsCtrl', function($scope, $location, Restangular, SweetAlert, $log, AuthService, $timeout, $anchorScroll, PaginationService) {
         Restangular.setFullResponse(true);

--- a/app/scripts/controllers/ProfileCtrl.js
+++ b/app/scripts/controllers/ProfileCtrl.js
@@ -1,5 +1,5 @@
 'use strict';
-define(['powerUp', 'AuthService', 'sweetalert.angular', 'loadingCircle'], function(powerUp) {
+define(['powerUp', 'AuthService', 'sweetalert.angular', 'loadingCircle', 'ratingStars'], function(powerUp) {
 
     powerUp.controller('ProfileCtrl', ['$scope', '$location', '$timeout', '$log', 'Restangular', 'AuthService', function($scope, $location, $timeout, $log, Restangular, AuthService) {
         Restangular.setFullResponse(true);

--- a/app/scripts/controllers/SearchCtrl.js
+++ b/app/scripts/controllers/SearchCtrl.js
@@ -1,5 +1,5 @@
 'use strict';
-define(['powerUp', 'loadingCircle', 'loadingCircleSmall', 'PaginationService'], function(powerUp) {
+define(['powerUp', 'loadingCircle', 'loadingCircleSmall', 'ratingStars', 'PaginationService'], function(powerUp) {
 
     powerUp.controller('SearchCtrl', ['$scope', '$timeout', '$location', '$log', 'Restangular', 'PaginationService', function ($scope, $timeout, $location, $log, Restangular, PaginationService) {
         Restangular.setFullResponse(true);

--- a/app/scripts/directives/ratingStars.html
+++ b/app/scripts/directives/ratingStars.html
@@ -1,0 +1,11 @@
+<div class="rating-stars">
+    <span ng-repeat="i in wholeStars() track by $index">
+        <i class="material-icons">star</i>
+    </span>
+    <span ng-repeat="i in halfStars() track by $index">
+        <i class="material-icons">star_half</i>
+    </span>
+    <span ng-repeat="i in emptyStars() track by $index">
+        <i class="material-icons">star_border</i>
+    </span>
+</div>

--- a/app/scripts/directives/ratingStars.js
+++ b/app/scripts/directives/ratingStars.js
@@ -1,0 +1,26 @@
+'use strict';
+define(['powerUp'], function(powerUp) {
+
+    powerUp.directive('ratingStars', function() {
+        return {
+            restrict: 'E',
+            templateUrl: 'scripts/directives/ratingStars.html',
+            scope: {
+                rating: '='
+            },
+            link: function($scope, $element, attrs, controller, transcludeFn) {
+                $scope.wholeStars = function() {
+                  return new Array(Math.floor($scope.rating / 2));
+                };
+
+              $scope.halfStars = function() {
+                return new Array(Math.floor($scope.rating % 2));
+              };
+
+              $scope.emptyStars = function() {
+                return new Array(5 - $scope.wholeStars().length - $scope.halfStars().length);
+              };
+            }
+        };
+    });
+});

--- a/app/views/games/game.html
+++ b/app/views/games/game.html
@@ -90,7 +90,7 @@
                     <div class="col s4">
                         <p><b>Rating</b></p>
                         <div ng-if="game.avgScore > 0">
-                            <p style="margin-top:0;"><span>{{game.avgScore | number:2}}</span></p>
+                            <p style="margin-top:0;"><span>{{game.avgScore | limitTo:4}}</span></p>
                         </div>
                         <div ng-if="game.avgScore <= 0">
                             <p style="margin-top:0;">unrated</p>

--- a/app/views/lists/lists.html
+++ b/app/views/lists/lists.html
@@ -94,30 +94,17 @@
                                     </b></p>
                                 </div>
                                 <div class="col s1 center">
-                                    <p style="margin-top: 33px;"><b>
-                                        {{(item.game.avgScore === null || item.game.avgScore == 0)?'No avg rating':(item.game.avgScore |
-                                        number:2)}}
-                                    </b>  </p>
+                                    <p style="margin-top: 33px;">
+                                        <b>{{(item.game.avgScore === null || item.game.avgScore == 0) ? 'Unrated' : (item.game.avgScore | limitTo:4)}}</b>
+                                    </p>
                                 </div>
                                 <div class="col s2 center">
                                     <div ng-switch="(item.score<=10 && item.score>0)">
                                         <div ng-switch-when="true" style="margin-top: 33px;">
-                                            <!--<p class="rating-number center">-->
-                                            <!--<b><span>{{item.score | limitTo:4}}</span></b>-->
-                                            <!--</p>-->
-                                            <span class="rating-stars hide-on-small-and-down">
-                                        <span ng-repeat="i in [0,1,2,3,4]">
-                                            <span ng-if="(item.score - (i * 2) - 1 ) < 0">
-                                                <i class="material-icons">star_border</i>
-                                            </span>
-                                            <span ng-if="(item.score - (i * 2) - 1 ) == 0">
-                                                <i class="material-icons">star_half</i>
-                                            </span>
-                                            <span ng-if="(item.score - (i * 2) - 1) > 0">
-                                                <i class="material-icons">star</i>
-                                            </span>
-                                        </span>
-                                    </span>
+                                            <p class="rating-number center">
+                                                <b><span>{{item.score | limitTo:4}}</span></b>
+                                            </p>
+                                            <rating-stars rating="item.score" class="rating-stars hide-on-small-and-down center"></rating-stars>
                                         </div>
                                         <div ng-switch-default style="margin-top: 33px;">
                                             <p class="rating-number center"><b>Unrated</b></p>

--- a/app/views/lists/lists.html
+++ b/app/views/lists/lists.html
@@ -103,7 +103,7 @@
                                     <div ng-switch="(item.score<=10 && item.score>0)">
                                         <div ng-switch-when="true" style="margin-top: 33px;">
                                             <!--<p class="rating-number center">-->
-                                            <!--<b><span>{{item.score | number:2}}</span></b>-->
+                                            <!--<b><span>{{item.score | limitTo:4}}</span></b>-->
                                             <!--</p>-->
                                             <span class="rating-stars hide-on-small-and-down">
                                         <span ng-repeat="i in [0,1,2,3,4]">

--- a/app/views/profile/profile.html
+++ b/app/views/profile/profile.html
@@ -64,7 +64,7 @@
                                 <div ng-switch="(entry.score <= 10 && entry.score > 0)">
                                     <div ng-switch-when="true">
                                         <!--TODO get score by user, not general score-->
-                                        <p class="rating-number center"><b><span>{{entry.score | number:2}}</span></b>
+                                        <p class="rating-number center"><b><span>{{entry.score | limitTo:4}}</span></b>
                                         </p>
                                         <p class="rating-stars hide-on-small-and-down">
                                             <!--range(0,4)-->

--- a/app/views/profile/profile.html
+++ b/app/views/profile/profile.html
@@ -64,22 +64,8 @@
                                 <div ng-switch="(entry.score <= 10 && entry.score > 0)">
                                     <div ng-switch-when="true">
                                         <!--TODO get score by user, not general score-->
-                                        <p class="rating-number center"><b><span>{{entry.score | limitTo:4}}</span></b>
-                                        </p>
-                                        <p class="rating-stars hide-on-small-and-down">
-                                            <!--range(0,4)-->
-                                        <div ng-repeat="i in [0,1,2,3,4]">
-                                            <div ng-if="(entry.score - (i * 2) - 1 ) < 0">
-                                                <i class="material-icons">star_border</i>
-                                            </div>
-                                            <div ng-if="(entry.score - (i * 2) - 1 ) == 0">
-                                                <i class="material-icons">star_half</i>
-                                            </div>
-                                            <div ng-if="(entry.score - (i * 2) - 1) > 0">
-                                                <i class="material-icons">star</i>
-                                            </div>
-                                        </div>
-                                        </p>
+                                        <p class="rating-number center"><b><span>{{entry.score | limitTo:4}}</span></b></p>
+                                        <rating-stars rating="entry.score" class="rating-stars hide-on-small-and-down center"></rating-stars>
                                     </div>
                                     <div ng-switch-default>
                                         <p class="rating-number center"><b>Unrated</b></p>

--- a/app/views/search/search.html
+++ b/app/views/search/search.html
@@ -137,21 +137,9 @@
                             <div ng-switch="(game.avgScore<=10 && game.avgScore>0)">
                                 <div ng-switch-when="true" style="margin-top: 20px;">
                                     <p class="rating-number center">
-                                        <b><span>{{game.avgScore | number:2}}</span></b>
+                                        <b><span>{{game.avgScore | limitTo:4}}</span></b>
                                     </p>
-                                    <span class="rating-stars hide-on-small-and-down">
-                                        <span ng-repeat="i in [0,1,2,3,4]">
-                                            <span ng-if="(game.avgScore - (i * 2) - 1 ) < 0">
-                                                <i class="material-icons">star_border</i>
-                                            </span>
-                                            <span ng-if="(game.avgScore - (i * 2) - 1 ) == 0">
-                                                <i class="material-icons">star_half</i>
-                                            </span>
-                                            <span ng-if="(game.avgScore - (i * 2) - 1) > 0">
-                                                <i class="material-icons">star</i>
-                                            </span>
-                                        </span>
-                                    </span>
+                                    <rating-stars rating="game.avgScore" class="rating-stars hide-on-small-and-down center"></rating-stars>
                                 </div>
                                 <div ng-switch-default style="margin-top: 33px;">
                                     <p class="rating-number center"><b>Unrated</b></p>


### PR DESCRIPTION
# Fix and improve rating stars and format of ratings

- Create and use directive for rating stars
- Center stars in their container
- Use truncation, not rounding, to display ratings (eg. 9.999 became 10.00, now it stays at 9.99)

# Screenshots
## Search
### Before (uncentered, top-rated game doesn't match rating with stars)
![192 168 1 42_paw-2016b-02_](https://user-images.githubusercontent.com/5761629/33798954-02d8245c-dd01-11e7-9d5e-0a3eb8e603ee.png)

### After
![localhost_9000_](https://user-images.githubusercontent.com/5761629/33798969-47edb642-dd01-11e7-8582-a5198878bd64.png)

## List
### Before
![image](https://user-images.githubusercontent.com/5761629/33798988-a101dbc8-dd01-11e7-92a8-6ba52fd50866.png)

### After
![image](https://user-images.githubusercontent.com/5761629/33798990-ac992b9e-dd01-11e7-9c28-9e8c03c04ce6.png)
