### PR TITLE
Change comment order in threads

### DIFF
--- a/app/scripts/controllers/ThreadCtrl.js
+++ b/app/scripts/controllers/ThreadCtrl.js
@@ -25,6 +25,7 @@ define(['powerUp', 'loadingCircle', 'loadingCircleSmall', 'sweetalert.angular', 
         };
         $scope.hasMoreComments = false;
         $scope.newComment = {};
+        $scope.newCommentId = null;
 
         // Get requested thread
         Restangular.one('threads', $scope.threadId).get().then(function(response) {
@@ -234,7 +235,8 @@ define(['powerUp', 'loadingCircle', 'loadingCircleSmall', 'sweetalert.angular', 
             $scope.thread.post('comments', newComment).then(function(response) {
                 // Fetch newly created comment
                 Restangular.oneUrl('routeName', response.headers('Location')).get().then(function(response) {
-                    $scope.comments.push(response.data);
+                    $scope.comments.unshift(response.data);
+                    $scope.newCommentId = response.data.id;
                     $scope.pendingRequests.comments.create = false;
                     $scope.newComment.body = '';
                 });
@@ -256,7 +258,8 @@ define(['powerUp', 'loadingCircle', 'loadingCircleSmall', 'sweetalert.angular', 
                     if (!parentComment.replies) {
                         parentComment.replies = [];
                     }
-                    parentComment.replies.push(response.data);
+                    parentComment.replies.unshift(response.data);
+                    $scope.newCommentId = response.data.id;
                     parentComment.replyCount++;
                     parentComment.replies.show = true;
                     // TODO also consider that this may throw off future results, because we have an element that is not

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -185,11 +185,11 @@ div.sweet-alert.show-input.showSweetAlert > h2 {
   margin: 5px !important;
 }
 
-.reply-action-links, a.toggle-replies {
-  color: #808080;
+.action-links a, .reply-action-links a.toggle-replies {
+  font-weight: 500
 }
 
-a.toggle-replies:hover {
+.reply-action-links a.toggle-replies:hover {
   text-decoration: underline;
 }
 

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -202,6 +202,10 @@ button#submit-search {
   margin-left: 5px;
 }
 
+.new-comment {
+  // TODO what to do? Border color? Background color? If changing background or border, remember to use !important
+}
+
 .preserve-newlines {
   white-space: pre-line;
 }

--- a/app/views/threads/thread.html
+++ b/app/views/threads/thread.html
@@ -66,8 +66,6 @@
 				</ul>
 			</div>
 
-			<div class="row col s12 divider"></div>
-
 			<!--COMMENTS-->
 			<div ng-if="comments === null" class="center">
 				<h5>Fetching thread comments...</h5>
@@ -75,11 +73,31 @@
 			</div>
 			<div ng-if="comments !== null">
 				<div class="row">
-					<h5 ng-if="comments.length == 0" class="center">No comments. Leave the first comment!</h5>
-					<h5 ng-if="comments.length > 0" class="center">Comments</h5>
+					<h4 ng-if="comments.length == 0" class="center">No comments. Leave the first comment!</h4>
+					<h4 ng-if="comments.length > 0" class="center">Comments</h4>
+
+					<!--Add a comment form-->
+					<div ng-if="isLoggedIn" class="row">
+						<form name="commentForm" class="css-form" ng-submit="createComment(newComment)">
+							<div class='row'>
+								<div class='input-field col s12'>
+									<textarea id="new-comment-textarea" type="text" ng-model="newComment.body" required="required" class="materialize-textarea"></textarea>
+									<label for="new-comment-textarea">New comment</label>
+								</div>
+							</div>
+							<div class='row'>
+								<div class="col s4 offset-s5">
+									<button type='submit' class='col s6 btn btn-large waves-effect light-blue' ng-disabled="pendingRequests.comments.create">
+										Submit <i class="material-icons right">send</i>
+									</button>
+								</div>
+							</div>
+						</form>
+					</div>
+					<!--End comment form-->
 
 					<ul class="collection" ng-if="comments.length > 0">
-						<li ng-repeat="comment in comments" class="collection-item avatar">
+						<li ng-repeat="comment in comments" class="collection-item avatar" ng-class="{'new-comment': comment.id === newCommentId}">
 							<!--Comment info-->
 							<a name="{{comment.id}}"></a>
 							<img ng-src="{{comment.commenter.profilePictureUrl}}" alt="{{comment.commenter.username}}" class="circle">
@@ -166,7 +184,7 @@
 							<!--Comment replies-->
 							<!--TODO FOR COMMENT RECURSION CHANGE FROM HERE-->
 							<ul class="collection" ng-if="comment.replies.length > 0" ng-show="comment.replies.show">
-								<li ng-repeat="comment in comment.replies" class="collection-item avatar">
+								<li ng-repeat="comment in comment.replies" class="collection-item avatar" ng-class="{'new-comment': comment.id === newCommentId}">
 									<!--Comment info-->
 									<a name="{{comment.id}}"></a>
 									<img ng-src="{{comment.commenter.profilePictureUrl}}" alt="{{comment.commenter.username}}" class="circle">
@@ -251,7 +269,7 @@
 
 									<!--Comment replies-2 TODO make everything the same directive and call it recursively-->
 									<ul class="collection" ng-if="comment.replies.length > 0" ng-show="comment.replies.show">
-										<li ng-repeat="comment in comment.replies" class="collection-item avatar">
+										<li ng-repeat="comment in comment.replies" class="collection-item avatar" ng-class="{'new-comment': comment.id === newCommentId}">
 											<!--Comment info-->
 											<a name="{{comment.id}}"></a>
 											<img ng-src="{{comment.commenter.profilePictureUrl}}" alt="{{comment.commenter.username}}" class="circle">
@@ -337,7 +355,7 @@
 
 											<!--Comment replies-3 TODO make everything the same directive and call it recursively-->
 											<ul class="collection" ng-if="comment.replies.length > 0" ng-show="comment.replies.show">
-												<li ng-repeat="comment in comment.replies" class="collection-item avatar">
+												<li ng-repeat="comment in comment.replies" class="collection-item avatar" ng-class="{'new-comment': comment.id === newCommentId}">
 													<!--Comment info-->
 													<a name="{{comment.id}}"></a>
 													<img ng-src="{{comment.commenter.profilePictureUrl}}" alt="{{comment.commenter.username}}" class="circle">
@@ -422,7 +440,7 @@
 													<!--End comment un/like section-->
 													<!--Comment replies-4 TODO make everything the same directive and call it recursively-->
 													<ul class="collection" ng-if="comment.replies.length > 0" ng-show="comment.replies.show">
-														<li ng-repeat="comment in comment.replies" class="collection-item avatar">
+														<li ng-repeat="comment in comment.replies" class="collection-item avatar" ng-class="{'new-comment': comment.id === newCommentId}">
 															<!--Comment info-->
 															<a name="{{comment.id}}"></a>
 															<img ng-src="{{comment.commenter.profilePictureUrl}}" alt="{{comment.commenter.username}}" class="circle">
@@ -537,26 +555,6 @@
 					</div>
 					<!--End load more comments-->
 				</div>
-
-				<!--Add a comment form-->
-				<div ng-if="isLoggedIn" class="row">
-					<form name="commentForm" class="css-form" ng-submit="createComment(newComment)">
-						<div class='row'>
-							<div class='input-field col s12'>
-								<textarea id="new-comment-textarea" type="text" ng-model="newComment.body" required="required" class="materialize-textarea"></textarea>
-								<label for="new-comment-textarea">New comment</label>
-							</div>
-						</div>
-						<div class='row'>
-							<div class="col s4 offset-s5">
-								<button type='submit' class='col s6 btn btn-large waves-effect light-blue' ng-disabled="pendingRequests.comments.create">
-									Submit <i class="material-icons right">send</i>
-								</button>
-							</div>
-						</div>
-					</form>
-				</div>
-				<!--End comment form-->
 			</div>
 		</div>
 		<!--END COMMENTS-->


### PR DESCRIPTION
- Always show new comments first, even though after a refresh they will be reordered chronologically
- Move "Add Comment" form to the top of comments, since created comment will appear first
- Apply class to newly created comment, if we want to style it especially later