### PR TITLE
Fix bugs due to incompatible Materialize versions

### DIFF
--- a/app/scripts/controllers/SearchCtrl.js
+++ b/app/scripts/controllers/SearchCtrl.js
@@ -303,8 +303,10 @@ define(['powerUp', 'loadingCircle', 'loadingCircleSmall', 'PaginationService'], 
                             $log.debug('Attempting to find autocomplete element for ' + filterCategory + ': ', element);
                             element.material_chip({
                                 data: initialChipData($scope.searchParams[filterCategory], filterCategory),
-                                placeholder: element.data('placeholder'),
-                                secondaryPlaceholder: element.data('secondary-placeholder'),
+                                // Materialize v0.99.0 has these inverted, unlike v0.100.1 and this code was originally made with v0.100.1
+                                // Doing the inversion here because it looks nicer on the HTML.
+                                placeholder: element.data('secondary-placeholder'),
+                                secondaryPlaceholder: element.data('placeholder'),
                                 autocompleteOptions: {
                                     data: arrayToObj(filters),
                                     // Max amount of results that can be shown at once. Default: Infinity.

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -194,7 +194,7 @@ a.toggle-replies:hover {
 }
 
 button#clear-filters, button#submit-search {
-  height:56px;
+  height:47px;
   box-shadow: none;
 }
 


### PR DESCRIPTION
#138 was developed with Materialize v0.100.1 (even though bower.json has a restriction of `^0.99.0` 🤔). The two versions are incompatible in a few things. This makes everything work with v0.99.0 which is the one used in production.

- Fix button height
- Fix placeholders