### PR TITLE
Fix resource 404s

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -321,7 +321,7 @@ module.exports = function (grunt) {
         files: [{
           expand: true,
           cwd: '<%= yeoman.app %>/styles',
-          src: ['**/*.scss'],
+          src: ['**/*.{css,scss}'],
           dest: '.tmp/styles'
         }]
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -170,7 +170,7 @@ module.exports = function (grunt) {
         src: [
           '<%= yeoman.dist %>/styles/**/*.css',
           '<%= yeoman.dist %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}',
-          '<%= yeoman.dist %>/styles/fonts/*',
+          // '<%= yeoman.dist %>/styles/fonts/**/*.{woff,woff2,eot,svg,ttf}',
           '<%= yeoman.dist %>/views/**/*.html',
           '<%= yeoman.dist %>/scripts/**/*.js',
           '<%= yeoman.dist %>/bower_components/**/*.js',
@@ -310,6 +310,11 @@ module.exports = function (grunt) {
           cwd: 'bower_components/slick-carousel/slick',
           src: 'ajax-loader.gif',
           dest: '.tmp/images'
+        }, {
+          expand: true,
+          cwd: 'bower_components/lightbox2/dist/images',
+          src: '*',
+          dest: '.tmp/images'
         }]
       },
       styles: {
@@ -337,8 +342,14 @@ module.exports = function (grunt) {
         }, {
           expand: true,
           cwd: '.tmp/images',
-          dest: '<%= yeoman.dist %>/images',
-          src: ['generated/*']
+          src: ['**/*'],
+          dest: '<%= yeoman.dist %>/images'
+        }, {
+          expand: true,
+          cwd: '.tmp/styles/fonts',
+          src: ['**/*'],
+          dest: '<%= yeoman.dist %>/styles/fonts'
+
         }, {
           expand: true,
           cwd: '.',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -291,6 +291,27 @@ module.exports = function (grunt) {
 
     // Copies remaining files to places other tasks can use
     copy: {
+      fonts: {
+        files: [{
+          expand: true,
+          cwd: 'bower_components/materialize/fonts',
+          src: '**/*',
+          dest: '.tmp/styles/fonts/materialize'
+        }, {
+          expand: true,
+          cwd: 'bower_components/slick-carousel/slick/fonts',
+          src: '**/*',
+          dest: '.tmp/styles/fonts'
+        }]
+      },
+      images: {
+        files: [{
+          expand: true,
+          cwd: 'bower_components/slick-carousel/slick',
+          src: 'ajax-loader.gif',
+          dest: '.tmp/images'
+        }]
+      },
       styles: {
         files: [{
           expand: true,
@@ -318,13 +339,7 @@ module.exports = function (grunt) {
           cwd: '.tmp/images',
           dest: '<%= yeoman.dist %>/images',
           src: ['generated/*']
-        }, /* {
-          TODO remove this Bootstrap configuration if Bootstrap isn't used
-          expand: true,
-          cwd: '.',
-          src: 'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/!*',
-          dest: '<%= yeoman.dist %>'
-        } */ {
+        }, {
           expand: true,
           cwd: '.',
           src: 'bower_components/requirejs/require.js',
@@ -462,6 +477,9 @@ module.exports = function (grunt) {
 
     grunt.task.run([
       'clean:server',
+      'copy:styles',
+      'copy:fonts',
+      'copy:images',
       'wiredep:serve',
       'concurrent:server',
       'autoprefixer',
@@ -481,6 +499,10 @@ module.exports = function (grunt) {
       'clean:dist',
       // copy stylesheets, in: app/styles/ out: .tmp/styles
       'copy:styles',
+      // copy fonts, out: .tmp/styles/fonts
+      'copy:fonts',
+      // copy some images that aren't properly copied beforehand
+      'copy:images',
       // Wires in bower dependencies where they belong in: <<>> out: <<>>
       'wiredep:dist',
       // In theory avoids problems related to name mangling by minifiers in: app/scripts out: .tmp/scripts

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,7 +169,7 @@ module.exports = function (grunt) {
       dist: {
         src: [
           '<%= yeoman.dist %>/styles/**/*.css',
-          '<%= yeoman.dist %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}',
+          // '<%= yeoman.dist %>/images/**/*.{png,jpg,jpeg,gif,webp,svg}',
           // '<%= yeoman.dist %>/styles/fonts/**/*.{woff,woff2,eot,svg,ttf}',
           '<%= yeoman.dist %>/views/**/*.html',
           '<%= yeoman.dist %>/scripts/**/*.js',

--- a/app/styles/lightbox.css
+++ b/app/styles/lightbox.css
@@ -1,0 +1,213 @@
+/* Preload images */
+body:after {
+    content: url(../images/close.png) url(../images/loading.gif) url(../images/prev.png) url(../images/next.png);
+    display: none;
+}
+
+body.lb-disable-scrolling {
+    overflow: hidden;
+}
+
+.lightboxOverlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 9999;
+    background-color: black;
+    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=80);
+    opacity: 0.8;
+    display: none;
+}
+
+.lightbox {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    z-index: 10000;
+    text-align: center;
+    line-height: 0;
+    font-weight: normal;
+}
+
+.lightbox .lb-image {
+    display: block;
+    height: auto;
+    max-width: inherit;
+    max-height: none;
+    border-radius: 3px;
+
+    /* Image border */
+    border: 4px solid white;
+}
+
+.lightbox a img {
+    border: none;
+}
+
+.lb-outerContainer {
+    position: relative;
+    *zoom: 1;
+    width: 250px;
+    height: 250px;
+    margin: 0 auto;
+    border-radius: 4px;
+
+    /* Background color behind image.
+       This is visible during transitions. */
+    background-color: white;
+}
+
+.lb-outerContainer:after {
+    content: "";
+    display: table;
+    clear: both;
+}
+
+.lb-loader {
+    position: absolute;
+    top: 43%;
+    left: 0;
+    height: 25%;
+    width: 100%;
+    text-align: center;
+    line-height: 0;
+}
+
+.lb-cancel {
+    display: block;
+    width: 32px;
+    height: 32px;
+    margin: 0 auto;
+    background: url(../images/loading.gif) no-repeat;
+}
+
+.lb-nav {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    z-index: 10;
+}
+
+.lb-container > .nav {
+    left: 0;
+}
+
+.lb-nav a {
+    outline: none;
+    background-image: url('data:image/gif;base64,R0lGODlhAQABAPAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==');
+}
+
+.lb-prev, .lb-next {
+    height: 100%;
+    cursor: pointer;
+    display: block;
+}
+
+.lb-nav a.lb-prev {
+    width: 34%;
+    left: 0;
+    float: left;
+    background: url(../images/prev.png) left 48% no-repeat;
+    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
+    opacity: 0;
+    -webkit-transition: opacity 0.6s;
+    -moz-transition: opacity 0.6s;
+    -o-transition: opacity 0.6s;
+    transition: opacity 0.6s;
+}
+
+.lb-nav a.lb-prev:hover {
+    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+    opacity: 1;
+}
+
+.lb-nav a.lb-next {
+    width: 64%;
+    right: 0;
+    float: right;
+    background: url(../images/next.png) right 48% no-repeat;
+    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
+    opacity: 0;
+    -webkit-transition: opacity 0.6s;
+    -moz-transition: opacity 0.6s;
+    -o-transition: opacity 0.6s;
+    transition: opacity 0.6s;
+}
+
+.lb-nav a.lb-next:hover {
+    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+    opacity: 1;
+}
+
+.lb-dataContainer {
+    margin: 0 auto;
+    padding-top: 5px;
+    *zoom: 1;
+    width: 100%;
+    -moz-border-radius-bottomleft: 4px;
+    -webkit-border-bottom-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    -moz-border-radius-bottomright: 4px;
+    -webkit-border-bottom-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+
+.lb-dataContainer:after {
+    content: "";
+    display: table;
+    clear: both;
+}
+
+.lb-data {
+    padding: 0 4px;
+    color: #ccc;
+}
+
+.lb-data .lb-details {
+    width: 85%;
+    float: left;
+    text-align: left;
+    line-height: 1.1em;
+}
+
+.lb-data .lb-caption {
+    font-size: 13px;
+    font-weight: bold;
+    line-height: 1em;
+}
+
+.lb-data .lb-caption a {
+    color: #4ae;
+}
+
+.lb-data .lb-number {
+    display: block;
+    clear: left;
+    padding-bottom: 1em;
+    font-size: 12px;
+    color: #999999;
+}
+
+.lb-data .lb-close {
+    display: block;
+    float: right;
+    width: 30px;
+    height: 30px;
+    background: url(../images/close.png) top right no-repeat;
+    text-align: right;
+    outline: none;
+    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=70);
+    opacity: 0.7;
+    -webkit-transition: opacity 0.2s;
+    -moz-transition: opacity 0.2s;
+    -o-transition: opacity 0.2s;
+    transition: opacity 0.2s;
+}
+
+.lb-data .lb-close:hover {
+    cursor: pointer;
+    filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+    opacity: 1;
+}

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -14,6 +14,22 @@ $roboto-font-path: "fonts/materialize/roboto/";
 @import '../../bower_components/slick-carousel/slick/slick-theme';
 // Lightbox
 @import '../../bower_components/lightbox2/dist/css/lightbox.min.css';
+// Lightbox image overrides
+body:after {
+    content: url(../images/close.png) url(../images/loading.gif) url(../images/prev.png) url(../images/next.png) !important;
+}
+.lb-cancel {
+    background: url(../images/loading.gif) no-repeat !important;
+}
+.lb-nav a.lb-prev {
+    background: url(../images/prev.png) left 48% no-repeat !important;
+}
+.lb-nav a.lb-next {
+    background: url(../images/next.png) right 48% no-repeat !important;
+}
+.lb-data .lb-close {
+    background: url(../images/close.png) top right no-repeat !important;
+}
 
 @import 'partials/home';
 @import 'style';

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -4,7 +4,7 @@
 // endbower
 
 // Materialize
-$roboto-font-path: "../../bower_components/materialize/fonts/roboto/";
+$roboto-font-path: "fonts/materialize/roboto/";
 @import '../../bower_components/materialize/sass/materialize';
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 // Swal

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -11,25 +11,8 @@ $roboto-font-path: "fonts/materialize/roboto/";
 // With path overrides because wiredep messes this up
 @import 'slick-theme.css';
 
-
-// Lightbox
-@import '../../bower_components/lightbox2/dist/css/lightbox.min.css';
-// Lightbox path overrides
-body:after {
-    content: url(../images/close.png) url(../images/loading.gif) url(../images/prev.png) url(../images/next.png) !important;
-}
-.lb-cancel {
-    background: url(../images/loading.gif) no-repeat !important;
-}
-.lb-nav a.lb-prev {
-    background: url(../images/prev.png) left 48% no-repeat !important;
-}
-.lb-nav a.lb-next {
-    background: url(../images/next.png) right 48% no-repeat !important;
-}
-.lb-data .lb-close {
-    background: url(../images/close.png) top right no-repeat !important;
-}
+// Lightbox (also path overrides)
+@import 'lightbox.css';
 
 @import 'partials/home';
 @import 'style';

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1,17 +1,17 @@
-//@import "materialize/sass/materialize";
-// bower:scss
-@import 'slick-carousel/slick/slick.scss';
-// endbower
-
 // Materialize
 $roboto-font-path: "fonts/materialize/roboto/";
 @import '../../bower_components/materialize/sass/materialize';
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
+
 // Swal
 @import '../../bower_components/sweetalert/dist/sweetalert.css';
+
 // Slick
 @import '../../bower_components/slick-carousel/slick/slick';
+$slick-loader-path: "images/";
+$slick-font-path: "styles/fonts/";
 @import '../../bower_components/slick-carousel/slick/slick-theme';
+
 // Lightbox
 @import '../../bower_components/lightbox2/dist/css/lightbox.min.css';
 // Lightbox image overrides

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -7,14 +7,14 @@ $roboto-font-path: "fonts/materialize/roboto/";
 @import '../../bower_components/sweetalert/dist/sweetalert.css';
 
 // Slick
-@import '../../bower_components/slick-carousel/slick/slick';
-$slick-loader-path: "images/";
-$slick-font-path: "styles/fonts/";
-@import '../../bower_components/slick-carousel/slick/slick-theme';
+@import '../../bower_components/slick-carousel/slick/slick.css';
+// With path overrides because wiredep messes this up
+@import 'slick-theme.css';
+
 
 // Lightbox
 @import '../../bower_components/lightbox2/dist/css/lightbox.min.css';
-// Lightbox image overrides
+// Lightbox path overrides
 body:after {
     content: url(../images/close.png) url(../images/loading.gif) url(../images/prev.png) url(../images/next.png) !important;
 }

--- a/app/styles/slick-theme.css
+++ b/app/styles/slick-theme.css
@@ -1,0 +1,204 @@
+@charset 'UTF-8';
+/* Slider */
+.slick-loading .slick-list
+{
+    background: #fff url('../images/ajax-loader.gif') center center no-repeat;
+}
+
+/* Icons */
+@font-face
+{
+    font-family: 'slick';
+    font-weight: normal;
+    font-style: normal;
+
+    src: url('./fonts/slick.eot');
+    src: url('./fonts/slick.eot?#iefix') format('embedded-opentype'), url('./fonts/slick.woff') format('woff'), url('./fonts/slick.ttf') format('truetype'), url('./fonts/slick.svg#slick') format('svg');
+}
+/* Arrows */
+.slick-prev,
+.slick-next
+{
+    font-size: 0;
+    line-height: 0;
+
+    position: absolute;
+    top: 50%;
+
+    display: block;
+
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    -webkit-transform: translate(0, -50%);
+    -ms-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+
+    cursor: pointer;
+
+    color: transparent;
+    border: none;
+    outline: none;
+    background: transparent;
+}
+.slick-prev:hover,
+.slick-prev:focus,
+.slick-next:hover,
+.slick-next:focus
+{
+    color: transparent;
+    outline: none;
+    background: transparent;
+}
+.slick-prev:hover:before,
+.slick-prev:focus:before,
+.slick-next:hover:before,
+.slick-next:focus:before
+{
+    opacity: 1;
+}
+.slick-prev.slick-disabled:before,
+.slick-next.slick-disabled:before
+{
+    opacity: .25;
+}
+
+.slick-prev:before,
+.slick-next:before
+{
+    font-family: 'slick';
+    font-size: 20px;
+    line-height: 1;
+
+    opacity: .75;
+    color: white;
+
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+.slick-prev
+{
+    left: -25px;
+}
+[dir='rtl'] .slick-prev
+{
+    right: -25px;
+    left: auto;
+}
+.slick-prev:before
+{
+    content: '←';
+}
+[dir='rtl'] .slick-prev:before
+{
+    content: '→';
+}
+
+.slick-next
+{
+    right: -25px;
+}
+[dir='rtl'] .slick-next
+{
+    right: auto;
+    left: -25px;
+}
+.slick-next:before
+{
+    content: '→';
+}
+[dir='rtl'] .slick-next:before
+{
+    content: '←';
+}
+
+/* Dots */
+.slick-dotted.slick-slider
+{
+    margin-bottom: 30px;
+}
+
+.slick-dots
+{
+    position: absolute;
+    bottom: -25px;
+
+    display: block;
+
+    width: 100%;
+    padding: 0;
+    margin: 0;
+
+    list-style: none;
+
+    text-align: center;
+}
+.slick-dots li
+{
+    position: relative;
+
+    display: inline-block;
+
+    width: 20px;
+    height: 20px;
+    margin: 0 5px;
+    padding: 0;
+
+    cursor: pointer;
+}
+.slick-dots li button
+{
+    font-size: 0;
+    line-height: 0;
+
+    display: block;
+
+    width: 20px;
+    height: 20px;
+    padding: 5px;
+
+    cursor: pointer;
+
+    color: transparent;
+    border: 0;
+    outline: none;
+    background: transparent;
+}
+.slick-dots li button:hover,
+.slick-dots li button:focus
+{
+    outline: none;
+}
+.slick-dots li button:hover:before,
+.slick-dots li button:focus:before
+{
+    opacity: 1;
+}
+.slick-dots li button:before
+{
+    font-family: 'slick';
+    font-size: 6px;
+    line-height: 20px;
+
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    width: 20px;
+    height: 20px;
+
+    content: '•';
+    text-align: center;
+
+    opacity: .25;
+    color: black;
+
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+.slick-dots li.slick-active button:before
+{
+    opacity: .75;
+    color: black;
+}


### PR DESCRIPTION
Various images and fonts used by Materialize, Slick and Lightbox were unavailable in dev, staging and/or production due to incorrect paths during the build process.  This PR fixes all those 404s.

- Copy lightbox CSS with custom paths
- Copy slick CSS with custom paths
- Copy styles, fonts and images during build process
- Disable filerevving for images and fonts since they will never change