### PR TITLE
Add pagination for filters

### DIFF
--- a/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/CompanyDao.java
+++ b/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/CompanyDao.java
@@ -1,10 +1,7 @@
 package ar.edu.itba.paw.webapp.interfaces;
 
 import ar.edu.itba.paw.webapp.model.Company;
-import ar.edu.itba.paw.webapp.model.Game;
-
-import java.util.List;
-import java.util.Set;
+import ar.edu.itba.paw.webapp.utilities.Page;
 
 /**
  * Data Access Object for Game Developers
@@ -12,9 +9,22 @@ import java.util.Set;
 public interface CompanyDao {
 
     /**
-     * @see CompanyService#all()
+     * Retrieves a paginated view of the stored developers.
+     *
+     * @param pageNumber The number of the {@link Page}.
+     * @param pageSize   The size of the {@link Page}.
+     * @return A Paginated view of the list of developers.
      */
-    List<Company> all();
+    Page<Company> developersPaginated(int pageNumber, int pageSize);
+
+    /**
+     * Retrieves a paginated view of the stored publishers.
+     *
+     * @param pageNumber The number of the {@link Page}.
+     * @param pageSize   The size of the {@link Page}.
+     * @return A Paginated view of the list of publishers.
+     */
+    Page<Company> publishersPaginated(int pageNumber, int pageSize);
 
     /**
      * @see CompanyService#findById(long)
@@ -25,14 +35,4 @@ public interface CompanyDao {
      * @see CompanyService#findByName(String)
      */
     Company findByName(String name);
-
-    /**
-     * @see CompanyService#gamesDevelopedBy(Company)
-     */
-    Set<Game> gamesDevelopedBy(Company p);
-
-    /**
-     * @see CompanyService#gamesPublishedBy(Company)
-     */
-    Set<Game> gamesPublishedBy(Company p);
 }

--- a/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/CompanyService.java
+++ b/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/CompanyService.java
@@ -1,22 +1,11 @@
 package ar.edu.itba.paw.webapp.interfaces;
 
 import ar.edu.itba.paw.webapp.model.Company;
-import ar.edu.itba.paw.webapp.model.Game;
-
-import java.util.List;
-import java.util.Set;
 
 /**
  * Service layer for game companies. Exposes functionality available to companies.
  */
 public interface CompanyService {
-
-    /**
-     * Finds all companies.
-     *
-     * @return An <b>unmodifiable</b> set containing all companies.
-     */
-    List<Company> all();
 
     /**
      * Finds a company by ID.
@@ -33,20 +22,4 @@ public interface CompanyService {
      * @return The matched company, or {@code null} if none found.
      */
     Company findByName(String name);
-
-    /**
-     * Gets all games that have been developed by a specified company.
-     *
-     * @param p The company to match.
-     * @return An <b>unmodifiable</b> set containing the matching games.
-     */
-    Set<Game> gamesDevelopedBy(Company p);
-
-    /**
-     * Gets all games that have been published by a specified company.
-     *
-     * @param p The company to match.
-     * @return An <b>unmodifiable</b> set containing the matching games.
-     */
-    Set<Game> gamesPublishedBy(Company p);
 }

--- a/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/GameService.java
+++ b/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/GameService.java
@@ -72,13 +72,15 @@ public interface GameService {
     boolean existsWithTitle(String title);
 
     /**
-     * Returns a collection with all the filters that can be applied to a specified {@link FilterCategory}.
+     * Returns a {@link Page} with filters that can be applied to a specified {@link FilterCategory}.
      *
+     * @param pageNumber     The number of the {@link Page}.
+     * @param pageSize       The size of the {@link Page}.
      * @param filterCategory The filter category.
      * @return A collection of strings in which each element is a value that can be applied
      * as a filter of the given category
      */
-    List<String> getFiltersByType(FilterCategory filterCategory);
+    Page<String> getFiltersByType(FilterCategory filterCategory, int pageNumber, int pageSize);
 
     /**
      * @return A random game id from the game database.

--- a/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/GenreDao.java
+++ b/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/GenreDao.java
@@ -2,18 +2,23 @@ package ar.edu.itba.paw.webapp.interfaces;
 
 import ar.edu.itba.paw.webapp.model.Game;
 import ar.edu.itba.paw.webapp.model.Genre;
+import ar.edu.itba.paw.webapp.utilities.Page;
 
-import java.util.List;
 import java.util.Set;
 
 /**
  * Data Access Object for Game Platforms
  */
 public interface GenreDao {
+
     /**
-     * @see GenreService#all()
+     * Retrieves a paginated view of the stored genres.
+     *
+     * @param pageNumber The number of the {@link Page}.
+     * @param pageSize   The size of the {@link Page}.
+     * @return A Paginated view of the list of genres.
      */
-    List<Genre> all();
+    Page<Genre> paginated(int pageNumber, int pageSize);
 
     /**
      * @see GenreService#findById(long)

--- a/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/GenreService.java
+++ b/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/GenreService.java
@@ -3,20 +3,12 @@ package ar.edu.itba.paw.webapp.interfaces;
 import ar.edu.itba.paw.webapp.model.Game;
 import ar.edu.itba.paw.webapp.model.Genre;
 
-import java.util.List;
 import java.util.Set;
 
 /**
  * Service layer for game genres. Exposes functionality available to genres.
  */
 public interface GenreService {
-
-    /**
-     * Finds all genres.
-     *
-     * @return An <b>unmodifiable</b> set containing all genres.
-     */
-    List<Genre> all();
 
     /**
      * Finds a genre by ID.

--- a/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/PlatformDao.java
+++ b/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/PlatformDao.java
@@ -2,9 +2,9 @@ package ar.edu.itba.paw.webapp.interfaces;
 
 import ar.edu.itba.paw.webapp.model.Game;
 import ar.edu.itba.paw.webapp.model.Platform;
+import ar.edu.itba.paw.webapp.utilities.Page;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -13,9 +13,13 @@ import java.util.Set;
 public interface PlatformDao {
 
     /**
-     * @see PlatformService#all()
+     * Retrieves a paginated view of the stored platforms.
+     *
+     * @param pageNumber The number of the {@link Page}.
+     * @param pageSize   The size of the {@link Page}.
+     * @return A Paginated view of the list of platforms.
      */
-    List<Platform> all();
+    Page<Platform> paginated(int pageNumber, int pageSize);
 
     /**
      * @see PlatformService#findById(long)

--- a/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/PlatformService.java
+++ b/paw-webapp/interfaces/src/main/java/ar/edu/itba/paw/webapp/interfaces/PlatformService.java
@@ -4,20 +4,12 @@ import ar.edu.itba.paw.webapp.model.Game;
 import ar.edu.itba.paw.webapp.model.Platform;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Set;
 
 /**
  * Service layer for game platforms. Exposes functionality available to platforms.
  */
 public interface PlatformService {
-
-    /**
-     * Finds all platforms.
-     *
-     * @return An <b>unmodifiable</b> set containing all platforms.
-     */
-    List<Platform> all();
 
     /**
      * Finds a platform by ID.

--- a/paw-webapp/model/src/main/java/ar/edu/itba/paw/webapp/model/FilterCategory.java
+++ b/paw-webapp/model/src/main/java/ar/edu/itba/paw/webapp/model/FilterCategory.java
@@ -7,9 +7,4 @@ public enum FilterCategory {
     genre,
     keyword,
     platform;
-
-    //TODO delete if unused
-    public String pretty() {
-        return ((Character)(name().charAt(0))).toString().toUpperCase() + name().substring(1);
-    }
 }

--- a/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/CompanyHibernateDao.java
+++ b/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/CompanyHibernateDao.java
@@ -1,18 +1,15 @@
 package ar.edu.itba.paw.webapp.persistence;
 
 import ar.edu.itba.paw.webapp.interfaces.CompanyDao;
+import ar.edu.itba.paw.webapp.interfaces.SortDirection;
 import ar.edu.itba.paw.webapp.model.Company;
-import ar.edu.itba.paw.webapp.model.Game;
+import ar.edu.itba.paw.webapp.utilities.Page;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Created by juanlipuma on Nov/1/16.
@@ -23,8 +20,19 @@ public class CompanyHibernateDao implements CompanyDao {
     private EntityManager em;
 
     @Override
-    public List<Company> all() {
-        return DaoHelper.findAll(em, Company.class);
+    public Page<Company> developersPaginated(int pageNumber, int pageSize) {
+        return DaoHelper.findPageWithoutConditions(em, Company.class,
+                "From Company as company inner join company.gamesDeveloped",
+                "company", "company.id",
+                pageNumber, pageSize, "company.id", SortDirection.ASC, true);
+    }
+
+    @Override
+    public Page<Company> publishersPaginated(int pageNumber, int pageSize) {
+        return DaoHelper.findPageWithoutConditions(em, Company.class,
+                "From Company as company inner join company.gamesPublished",
+                "company", "company.id",
+                pageNumber, pageSize, "company.id", SortDirection.ASC, true);
     }
 
     @Override
@@ -42,18 +50,5 @@ public class CompanyHibernateDao implements CompanyDao {
         } catch (NoResultException e) {
             return null;
         }
-    }
-
-
-    // TODO: Check these two methods bellow --> They aren't needed here
-
-    @Override
-    public Set<Game> gamesDevelopedBy(Company d) {
-        return Collections.unmodifiableSet(new LinkedHashSet<>(d.getGamesDeveloped()));
-    }
-
-    @Override
-    public Set<Game> gamesPublishedBy(Company p) {
-        return Collections.unmodifiableSet(new LinkedHashSet<>(p.getGamesPublished()));
     }
 }

--- a/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/DaoHelper.java
+++ b/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/DaoHelper.java
@@ -208,6 +208,30 @@ import java.util.stream.IntStream;
     }
 
     /**
+     * Retrieves a {@link Page} without applying conditions.
+     *
+     * @param em            The entity manager.
+     * @param klass         The entity's class.
+     * @param baseQuery     A {@link StringBuilder} containing the base query.
+     * @param baseAlias     The alias used for the entity in the base query.
+     * @param countField    The field used to count.
+     * @param pageNumber    The number of page.
+     * @param pageSize      The size of page.
+     * @param sortByField   The field used to sort.
+     * @param sortDirection The sort direction (i.e ASC or DESC).
+     * @param <T>           The type of the entity.
+     * @return The page containing the data.
+     */
+    /* package */
+    static <T> Page<T> findPageWithoutConditions(EntityManager em, Class<T> klass, String baseQuery,
+                                                 String baseAlias, String countField,
+                                                 int pageNumber, int pageSize, String sortByField,
+                                                 SortDirection sortDirection, boolean includeSelect) {
+        return findPageWithConditions(em, klass, baseQuery, baseAlias, countField, Collections.emptyList(),
+                pageNumber, pageSize, sortByField, sortDirection, includeSelect);
+    }
+
+    /**
      * Performs a basic search with parameters, returning a page of results.
      *
      * @param <T>           The return type.

--- a/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/GameHibernateDao.java
+++ b/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/GameHibernateDao.java
@@ -43,7 +43,7 @@ public class GameHibernateDao implements GameDao {
                 if (firstArgument) {
                     firstArgument = false;
                     if (!(filterCategory.name().equals("platform"))) {
-                        fromString.append(" join g.").append(filterCategory.pretty().toLowerCase()).append("s as ").append(filterCategory.name());
+                        fromString.append(" join g.").append(filterCategory.name().toLowerCase()).append("s as ").append(filterCategory.name());
                     } else {
                         fromString.append(" , Platform as platform");
                     }

--- a/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/GenreHibernateDao.java
+++ b/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/GenreHibernateDao.java
@@ -1,8 +1,10 @@
 package ar.edu.itba.paw.webapp.persistence;
 
 import ar.edu.itba.paw.webapp.interfaces.GenreDao;
+import ar.edu.itba.paw.webapp.interfaces.SortDirection;
 import ar.edu.itba.paw.webapp.model.Game;
 import ar.edu.itba.paw.webapp.model.Genre;
+import ar.edu.itba.paw.webapp.utilities.Page;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
@@ -11,7 +13,6 @@ import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -25,8 +26,10 @@ public class GenreHibernateDao implements GenreDao {
     private EntityManager em;
 
     @Override
-    public List<Genre> all() {
-        return DaoHelper.findAll(em, Genre.class);
+    public Page<Genre> paginated(int pageNumber, int pageSize) {
+        return DaoHelper.findPageWithoutConditions(em, Genre.class,
+                "From Genre as genre", "genre", "id",
+                pageNumber, pageSize, "id", SortDirection.ASC, true);
     }
 
     @Override

--- a/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/PlatformHibernateDao.java
+++ b/paw-webapp/persistence/src/main/java/ar/edu/itba/paw/webapp/persistence/PlatformHibernateDao.java
@@ -1,9 +1,11 @@
 package ar.edu.itba.paw.webapp.persistence;
 
 import ar.edu.itba.paw.webapp.interfaces.PlatformDao;
+import ar.edu.itba.paw.webapp.interfaces.SortDirection;
 import ar.edu.itba.paw.webapp.model.Game;
 import ar.edu.itba.paw.webapp.model.GamePlatformReleaseDate;
 import ar.edu.itba.paw.webapp.model.Platform;
+import ar.edu.itba.paw.webapp.utilities.Page;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
@@ -13,7 +15,6 @@ import javax.persistence.TypedQuery;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -24,10 +25,11 @@ public class PlatformHibernateDao implements PlatformDao {
     @PersistenceContext
     private EntityManager em;
 
-
     @Override
-    public List<Platform> all() {
-        return DaoHelper.findAll(em, Platform.class);
+    public Page<Platform> paginated(int pageNumber, int pageSize) {
+        return DaoHelper.findPageWithoutConditions(em, Platform.class,
+                "From Platform as platform", "platform", "id",
+                pageNumber, pageSize, "id", SortDirection.ASC, true);
     }
 
     @Override

--- a/paw-webapp/service/src/main/java/ar/edu/itba/paw/webapp/service/CompanyServiceImpl.java
+++ b/paw-webapp/service/src/main/java/ar/edu/itba/paw/webapp/service/CompanyServiceImpl.java
@@ -3,13 +3,9 @@ package ar.edu.itba.paw.webapp.service;
 import ar.edu.itba.paw.webapp.interfaces.CompanyDao;
 import ar.edu.itba.paw.webapp.interfaces.CompanyService;
 import ar.edu.itba.paw.webapp.model.Company;
-import ar.edu.itba.paw.webapp.model.Game;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Set;
 
 
 @Service
@@ -24,11 +20,6 @@ public class CompanyServiceImpl implements CompanyService {
     }
 
     @Override
-    public List<Company> all() {
-        return companyDao.all();
-    }
-
-    @Override
     public Company findById(long id) {
         return companyDao.findById(id);
     }
@@ -36,15 +27,5 @@ public class CompanyServiceImpl implements CompanyService {
     @Override
     public Company findByName(String name) {
         return companyDao.findByName(name);
-    }
-
-    @Override
-    public Set<Game> gamesDevelopedBy(Company d) {
-        return companyDao.gamesDevelopedBy(d);
-    }
-
-    @Override
-    public Set<Game> gamesPublishedBy(Company p) {
-        return companyDao.gamesPublishedBy(p);
     }
 }

--- a/paw-webapp/service/src/main/java/ar/edu/itba/paw/webapp/service/GameServiceImpl.java
+++ b/paw-webapp/service/src/main/java/ar/edu/itba/paw/webapp/service/GameServiceImpl.java
@@ -22,7 +22,7 @@ public class GameServiceImpl implements GameService {
     private final static int MAGIC_PAGE_SIZE = 100;
 
 
-    private static List<String> KEYWORDS_EMPTY_LIST = new LinkedList<>();
+    private static Page<String> KEYWORDS_EMPTY_PAGE = Page.emptyPage();
 
     private GameDao gameDao;
 
@@ -73,22 +73,30 @@ public class GameServiceImpl implements GameService {
         return gameDao.existsWithTitle(title);
     }
 
-    public List<String> getFiltersByType(FilterCategory filterCategory) {
+    @Override
+    public Page<String> getFiltersByType(FilterCategory filterCategory, int pageNumber, int pageSize) {
         switch (filterCategory) {
-            case genre:
-                return genreDao.all().stream().map(Genre::getName).collect(Collectors.toList());
-            case keyword:
-                return KEYWORDS_EMPTY_LIST;
-            case platform:
-                return platformDao.all().stream().map(Platform::getName).collect(Collectors.toList());
-            case developer:
-                return companyDao.all().stream().filter(each -> !each.getGamesDeveloped().isEmpty())
-                        .map(Company::getName).collect(Collectors.toList());
-            case publisher:
-                return companyDao.all().stream().filter(each -> !each.getGamesPublished().isEmpty())
-                        .map(Company::getName).collect(Collectors.toList());
+            case genre: {
+                final Page<Genre> original = genreDao.paginated(pageNumber, pageSize);
+                return ServiceHelper.fromAnotherPage(original, Genre::getName).build();
+            }
+            case keyword: {
+                return KEYWORDS_EMPTY_PAGE;
+            }
+            case platform: {
+                final Page<Platform> original = platformDao.paginated(pageNumber, pageSize);
+                return ServiceHelper.fromAnotherPage(original, Platform::getName).build();
+            }
+            case developer: {
+                final Page<Company> original = companyDao.developersPaginated(pageNumber, pageSize);
+                return ServiceHelper.fromAnotherPage(original, Company::getName).build();
+            }
+            case publisher: {
+                final Page<Company> original = companyDao.publishersPaginated(pageNumber, pageSize);
+                return ServiceHelper.fromAnotherPage(original, Company::getName).build();
+            }
             default:
-                throw new RuntimeException("Something went wrong");
+                throw new RuntimeException("Something went wrong"); // Won't never reach here.
         }
     }
 

--- a/paw-webapp/service/src/main/java/ar/edu/itba/paw/webapp/service/GenreServiceImpl.java
+++ b/paw-webapp/service/src/main/java/ar/edu/itba/paw/webapp/service/GenreServiceImpl.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Set;
 
 
@@ -21,11 +20,6 @@ public class GenreServiceImpl implements GenreService {
     @Autowired
     public GenreServiceImpl(GenreDao genreDao) {
         this.genreDao = genreDao;
-    }
-
-    @Override
-    public List<Genre> all() {
-        return genreDao.all();
     }
 
     @Override

--- a/paw-webapp/service/src/main/java/ar/edu/itba/paw/webapp/service/PlatformServiceImpl.java
+++ b/paw-webapp/service/src/main/java/ar/edu/itba/paw/webapp/service/PlatformServiceImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Set;
 
 
@@ -22,11 +21,6 @@ public class PlatformServiceImpl implements PlatformService {
     @Autowired
     public PlatformServiceImpl(PlatformDao platformDao) {
         this.platformDao = platformDao;
-    }
-
-    @Override
-    public List<Platform> all() {
-        return platformDao.all();
     }
 
     @Override

--- a/paw-webapp/webapp/src/main/java/ar/edu/itba/paw/webapp/controller/GameJerseyController.java
+++ b/paw-webapp/webapp/src/main/java/ar/edu/itba/paw/webapp/controller/GameJerseyController.java
@@ -3,7 +3,6 @@ package ar.edu.itba.paw.webapp.controller;
 import ar.edu.itba.paw.webapp.dto.FilterValueDto;
 import ar.edu.itba.paw.webapp.dto.GameDto;
 import ar.edu.itba.paw.webapp.dto.TwitchStreamDto;
-import ar.edu.itba.paw.webapp.exceptions.IllegalParameterValueException;
 import ar.edu.itba.paw.webapp.interfaces.GameService;
 import ar.edu.itba.paw.webapp.interfaces.SortDirection;
 import ar.edu.itba.paw.webapp.interfaces.TwitchService;
@@ -132,15 +131,16 @@ public class GameJerseyController {
     @GET
     @Path("/filters/{type}")
     public Response getFiltersByType(@PathParam("type") final FilterCategory filterCategory,
-                                     @QueryParam("pageNumber") @DefaultValue("1") final int pageNumber) {
+                                     @QueryParam("pageNumber") @DefaultValue("1") final int pageNumber,
+                                     @QueryParam("pageSize") @DefaultValue("500") final int pageSize) {
         // Validate stuff
         final JerseyControllerHelper.ParametersWrapper wrapper = JerseyControllerHelper.getParametersWrapper()
                 .addParameter("type", filterCategory, Objects::isNull)
-                .addParameter("pageNumber", pageNumber, number -> number <= 0);
+                .addParameter("pageNumber", pageNumber, number -> number <= 0)
+                .addParameter("pageSize", pageSize, size -> size <= 0 || size > 500);
         JerseyControllerHelper.checkParameters(wrapper);
 
         // Get page of filters
-        final int pageSize = 500;  // Will return always chunks of 500 elements
         final Page<String> page = gameService.getFiltersByType(filterCategory, pageNumber, pageSize);
 
         // Generate URLs for all pages

--- a/paw-webapp/webapp/src/main/java/ar/edu/itba/paw/webapp/dto/FilterValueDto.java
+++ b/paw-webapp/webapp/src/main/java/ar/edu/itba/paw/webapp/dto/FilterValueDto.java
@@ -1,13 +1,11 @@
 package ar.edu.itba.paw.webapp.dto;
 
-import ar.edu.itba.paw.webapp.model.FilterCategory;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -32,7 +30,6 @@ public class FilterValueDto {
     }
 
 
-
     public String getValue() {
         return value;
     }
@@ -43,8 +40,7 @@ public class FilterValueDto {
      *
      * @return A list of {@link FilterValueDto}.
      */
-    public static List<FilterValueDto> createList(List<String> values) {
+    public static List<FilterValueDto> createList(Collection<String> values) {
         return values.stream().map(FilterValueDto::new).collect(Collectors.toList());
     }
-
 }


### PR DESCRIPTION
Closes #11 
This branch will add pagination for filters

Note that it also improves queries to get developers and publishers, which were the ones that make it so slow to get all filters.

**Some basic instructions:**
Add the ```pageNumber``` query param to the ```GET /games/filters/:type``` request to indicate which page you want. Response will return chunks of 500 elements.